### PR TITLE
Initial Gamepad support

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,12 @@ If your game doesn't have other screens, just call this after your `runApp` call
 
 [Complete Input Guide](doc/input.md)
 
+### Gamepad
+
+Gamepad is partially supported on Android, you easily listen to key up and down events using `Flame.gamepad.addListener` method, check the link below for the complete guide
+
+[Complete Gamepad Guide](doc/gamepad.md)
+
 ## Credits
 
  * All the friendly contributors and people who are helping in the community.

--- a/doc/gamepad.md
+++ b/doc/gamepad.md
@@ -1,0 +1,44 @@
+# Gamepad
+
+## Gamepad is only support on Android at the moment.
+
+To listen to gamepad events use the 'Flame.gamepad' instance, to add a listener use following snippet.
+
+```dart
+  Flame.gamepad.addListener((String evtType, String key) {
+    print(key)
+    if (evtType == GAMEPAD_BUTTON_UP) {
+      print('is up')
+    } else {
+      print('is down')
+    }
+  });
+```
+
+To check for specific keys use the following constants avaiable on the package: `flame/game.dart`
+
+```
+GAMEPAD_BUTTON_UP
+GAMEPAD_BUTTON_DOWN
+
+GAMEPAD_DPAD_UP
+GAMEPAD_DPAD_DOWN
+GAMEPAD_DPAD_LEFT
+GAMEPAD_DPAD_RIGHT
+
+GAMEPAD_BUTTON_A
+GAMEPAD_BUTTON_B
+GAMEPAD_BUTTON_X
+GAMEPAD_BUTTON_Y
+
+GAMEPAD_BUTTON_L1
+GAMEPAD_BUTTON_L2
+
+GAMEPAD_BUTTON_R1
+GAMEPAD_BUTTON_R2
+
+GAMEPAD_BUTTON_START
+GAMEPAD_BUTTON_SELECT
+```
+
+A functional example can be found [here](https://github.com/erickzanardo/flame-gamepad-example)

--- a/lib/flame.dart
+++ b/lib/flame.dart
@@ -8,6 +8,9 @@ import 'package:flutter/widgets.dart';
 import 'audio.dart';
 import 'images.dart';
 import 'util.dart';
+import 'gamepad.dart';
+
+export 'gamepad.dart';
 
 /// This class holds static references to some useful objects to use in your game.
 ///
@@ -23,6 +26,9 @@ class Flame {
 
   /// Access a shared instance of the [Util] class.
   static Util util = new Util();
+
+  /// Access a shared instance of the [Gamepad] class.
+  static Gamepad gamepad = new Gamepad();
 
   /// TODO verify if this is still needed (I don't think so)
   static void initialize() {

--- a/lib/gamepad.dart
+++ b/lib/gamepad.dart
@@ -44,7 +44,7 @@ const ANDROID_MAPPING = {
 
 /// Gampad functionalities
 ///
-/// To use this class, access it via [Flame.gampad].
+/// To use this class, access it via [Flame.gamepad].
 class Gamepad {
 
   KeyListener listener;

--- a/lib/gamepad.dart
+++ b/lib/gamepad.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/services.dart';
+
+typedef void KeyListener (RawKeyEvent event);
+typedef void GamepadListener (String evtType, String key);
+
+const GAMEPAD_BUTTON_UP = "UP";
+const GAMEPAD_BUTTON_DOWN = "DOWN";
+
+const GAMEPAD_DPAD_UP = "UP";
+const GAMEPAD_DPAD_DOWN = "DOWN";
+const GAMEPAD_DPAD_LEFT = "LEFT";
+const GAMEPAD_DPAD_RIGHT = "RIGHT";
+
+const GAMEPAD_BUTTON_A = "A";
+const GAMEPAD_BUTTON_B = "B";
+const GAMEPAD_BUTTON_X = "X";
+const GAMEPAD_BUTTON_Y = "Y";
+
+const GAMEPAD_BUTTON_L1 = "L1";
+const GAMEPAD_BUTTON_L2 = "L2";
+
+const GAMEPAD_BUTTON_R1 = "R1";
+const GAMEPAD_BUTTON_R2 = "R2";
+
+const GAMEPAD_BUTTON_START = "START";
+const GAMEPAD_BUTTON_SELECT = "SELECT";
+
+const ANDROID_MAPPING = {
+  19:  GAMEPAD_DPAD_UP,
+  20:  GAMEPAD_DPAD_DOWN,
+  21:  GAMEPAD_DPAD_LEFT,
+  22:  GAMEPAD_DPAD_RIGHT,
+  96:  GAMEPAD_BUTTON_A,
+  97:  GAMEPAD_BUTTON_B,
+  99:  GAMEPAD_BUTTON_X,
+  100: GAMEPAD_BUTTON_Y,
+  102: GAMEPAD_BUTTON_L1,
+  103: GAMEPAD_BUTTON_R1,
+  104: GAMEPAD_BUTTON_L2,
+  105: GAMEPAD_BUTTON_R2,
+  108: GAMEPAD_BUTTON_START,
+  109: GAMEPAD_BUTTON_SELECT
+};
+
+/// Gampad functionalities
+///
+/// To use this class, access it via [Flame.gampad].
+class Gamepad {
+
+  KeyListener listener;
+
+  void addListener(GamepadListener gamepadListener) {
+    this.listener = (RawKeyEvent e) {
+      String evtType = e is RawKeyDownEvent ? GAMEPAD_BUTTON_DOWN : GAMEPAD_BUTTON_UP;
+
+      if (e.data is RawKeyEventDataAndroid) {
+        RawKeyEventDataAndroid androidEvent = e.data as RawKeyEventDataAndroid;
+
+        String key = ANDROID_MAPPING[androidEvent.keyCode];
+        if (key != null) {
+          gamepadListener(evtType, key);
+        }
+      }
+    };
+
+    RawKeyboard.instance.addListener(this.listener);
+  }
+
+  void removeListener() {
+    RawKeyboard.instance.removeListener(this.listener);
+  }
+}


### PR DESCRIPTION
This PR adds an initial gamepad support on Flame.

Only Android is supported on this PR, I don`t think iOs support will be possible only using the resources provided by flutter, therefore some native code will be needed.

On Android all keys except the axes are supported, which I guess will also require native code.