### PR TITLE
Fix widget change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.9.3]
+
+- Fixes issue when switching between games where new game would not attach
+
 ## [0.9.2]
 - Fixes to work with Dart 2.1
 

--- a/lib/game.dart
+++ b/lib/game.dart
@@ -62,6 +62,11 @@ class _GameRenderObjectWidget extends SingleChildRenderObjectWidget {
   @override
   RenderObject createRenderObject(BuildContext context) =>
       new _GameRenderBox(context, this.game);
+
+  @override
+  void updateRenderObject(BuildContext context, _GameRenderBox _gameRenderBox) {
+    _gameRenderBox.game = game;
+  }
 }
 
 class _GameRenderBox extends RenderBox with WidgetsBindingObserver {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flame
 description: A minimalist Flutter game engine, provides a nice set of somewhat independent modules you can choose from.
-version: 0.9.2
+version: 0.9.3
 author: Luan Nico <luannico27@gmail.com>
 homepage: https://github.com/luanpotter/flame
 


### PR DESCRIPTION
I had an issue where when switching between two different game widgets, the widget would not change. e.g.

* _onGameOver is a method called when the user finishes that minigame
```dart
class GamePageState extends State<GamePage> {
  int _nextGame = 0;
  MyBaseGame _currentGame;
  List<String> games = <String>['Game1', 'Game2'];

  @override
  void initState() {
    super.initState();
    _currentGame = _genGame(games[_nextGame++]);
  }

  void _onGameOver(double seconds) {
    if (_nextGame >= games.length) {
      // Do something
    } else {
      setState(() {
        _currentGame = _genGame(games[_nextGame++]);
      });
    }
  }

  MyBaseGame _genGame(String gameName) {
    switch (gameName) {
      case 'Game1':
        return Game1(onGameOver: _onGameOver);
      case 'Game2':
        return Game2(onGameOver: _onGameOver);
      default:
        throw UnimplementedError();
    }
  }

  @override
  Widget build(BuildContext context) {
    return _currentGame.widget;
  }
}
```