### PR TITLE
Add elapsed time to Animation

### DIFF
--- a/lib/animation.dart
+++ b/lib/animation.dart
@@ -25,6 +25,9 @@ class Animation {
   /// It's ticked by the update method. It's reset every frame change.
   double clock = 0.0;
 
+  /// Total elapsed time of this animation, in seconds, since start or a reset.
+  double elapsed = 0.0;
+
   /// Wether the animation loops after the last sprite of the list, going back to the first, or keeps returning the last when done.
   bool loop = true;
 
@@ -120,6 +123,7 @@ class Animation {
   /// Resets the animation, like it'd just been created.
   void reset() {
     this.clock = 0.0;
+    this.elapsed = 0.0;
     this.currentIndex = 0;
   }
 
@@ -141,6 +145,7 @@ class Animation {
   /// Updates this animation, ticking the lifeTime by an amount [dt] (in seconds).
   void update(double dt) {
     clock += dt;
+    elapsed += dt;
     if (!loop && isLastFrame) {
       return;
     }


### PR DESCRIPTION
Disclaimer: Hello! This is my first PR to this repository, hope it is useful.

I was implementing [flame-example](https://github.com/luanpotter/flame-example) with the latest release of Flame (0.9.4), and the `Animation.lifeTime` property doesn't exists anymore. I tried swapping with the `.clock` property, but I think it changed semantics to count the elapsed time since last frame, so I ended up creating another property, `.ellapsed`, to indicate how long (in seconds) an animation has been running. This allows flame-example to work again.