### PR TITLE
Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Flame is modular, and you can always pick and choose. Some modules are extracted
 * [tiled](https://github.com/feroult/tiled.dart) adds support for parsing and using TMX files from Tiled. It's included.
 * [box2d](https://github.com/feroult/box2d.dart) adds wrappers over Box2D for the physics engine. It's included.
 
-* [flame_gamepad](https://github.com/fireslime/flame_gamepad) adds support to gamepad. Aandroid only. It's not included, add to your pubspec as desired.
+* [flame_gamepad](https://github.com/fireslime/flame_gamepad) adds support to gamepad. Android only. It's not included, add to your pubspec as desired.
 * [play_games](https://github.com/luanpotter/play_games) integrates to Google Play Games Servies (GPGS). Adds login, achievements, saved games and leaderboard. Android only. It's not included, add to your pubspec as desired. Be sure to check the instructions on how to configure, as it's not trivial.
 
 ## Usage


### PR DESCRIPTION
Hi, I fixed a typo in the README file for the *flame_gamepad* module's description