### PR TITLE
Bump synchronized to 2.1.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   ordered_set: ^1.1.2
   path_provider: ^0.5.0
   box2d_flame: ^0.4.2
-  synchronized: ^1.5.1+1
+  synchronized: ^2.1.0
   tiled: ^0.2.1
   convert: ^2.0.1
   flutter_svg: ^0.12.4


### PR DESCRIPTION
Avoiding conflict with other packages (in my specific case, `cached_network_image`)