### PR TITLE
Upgrading flutter_svg and fixing version on pubspec for developer branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ addons:
       - libstdc++6
       - fonts-droid
 before_script:
-  - git clone https://github.com/flutter/flutter.git -b beta --depth 1
+  - git clone https://github.com/flutter/flutter.git -b dev --depth 1
   - mv flutter $HOME/flutter
   - export PATH=$HOME/flutter/bin:$PATH
   - flutter doctor

--- a/README.md
+++ b/README.md
@@ -48,7 +48,9 @@ dependencies:
 
 And start using it!
 
-Be sure to be using at least Flutter beta channel (1.4.9-hotfix.1). There was a breaking change on Flutter that we fixed but it's not on the stable channel yet. We intend to switch to stable once this change is released. For more information about flutter channels, please check [this link](https://github.com/flutter/flutter/wiki/Flutter-build-release-channels).
+__Important__
+
+We strive to keep Flame working on the Flutter's dev channel, currently on version 1.6.1, be sure to check which channel are you using if you encounter any trouble.
 
 ## Documentation
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flame
 description: A minimalist Flutter game engine, provides a nice set of somewhat independent modules you can choose from.
-version: 0.11.1
+version: 0.11.2
 author: Luan Nico <luannico27@gmail.com>
 homepage: https://github.com/luanpotter/flame
 
@@ -17,7 +17,7 @@ dependencies:
   synchronized: ^2.1.0
   tiled: ^0.2.1
   convert: ^2.0.1
-  flutter_svg: ^0.12.4
+  flutter_svg: ^0.13.0+1
 
 dev_dependencies:
   flutter_test:
@@ -26,4 +26,4 @@ dev_dependencies:
 
 environment:
   sdk: ">=2.2.0 <3.0.0"
-  flutter: ">=1.2.0 <2.0.0"
+  flutter: ">=1.6.0 <2.0.0"


### PR DESCRIPTION
This PR updates flutter_svg to its latest version, those breaking changes that were on flutter's master channel has already landed on dev channel, so we can now upgrade it.

This also fixes the package version, and flutter version requirement on pubspec for the develop branch, which was still outdated. And updates the README with information regarding Flame's version requirement.

